### PR TITLE
Unique Projects Page + Field-Level Permissions

### DIFF
--- a/hxydra/src/components/EditForm.vue
+++ b/hxydra/src/components/EditForm.vue
@@ -975,6 +975,7 @@
     mounted() {
       this.getChoices()
       this.getPeople()
+      console.log(this.course, "read me")
     },
     methods: {
       getChoices () {

--- a/hxydra/src/components/EditForm.vue
+++ b/hxydra/src/components/EditForm.vue
@@ -1012,7 +1012,6 @@
     mounted() {
       this.getChoices()
       this.getPeople()
-      console.log(this.course, "read me")
     },
     methods: {
       getChoices () {

--- a/hxydra/src/components/EditForm.vue
+++ b/hxydra/src/components/EditForm.vue
@@ -69,6 +69,7 @@
               :items="school"
               label="Revenue Schools"
               multiple
+              :disabled="!('revenue_school' in course.writeable)"
               @input="revSchoolUpdated"
             />
           </v-col>
@@ -76,6 +77,7 @@
             <v-text-field
               v-model="course.subactivity"
               label="Subactivity"
+              :disabled="!('subactivity' in course.writeable)"
               required
             />
           </v-col>
@@ -84,6 +86,7 @@
               v-model="course.status"
               :items="projectstatus"
               label="Status"
+              :disabled="!('status' in course.writeable)"
             />
           </v-col>
         </v-row>
@@ -93,6 +96,7 @@
               v-model="course.description"
               label="Course Description"
               outlined
+              :disabled="!('description' in course.writeable)"
             />
           </v-col>
         </v-row>
@@ -102,6 +106,7 @@
               v-model="course.summary"
               label="Course Short Summary"
               outlined
+              :disabled="!('summary' in course.writeable)"
             />
           </v-col>
         </v-row>
@@ -151,6 +156,7 @@
                 v-model="quickfilledx"
                 label="Quick-Fill edX"
                 placeholder="course-v1:HarvardX+PH211x+1T2021"
+                :disabled="!('program_run' in course.writeable) || !('program_number' in course.writeable)"
               />
             </v-col>
             <v-col class="col-6">
@@ -158,6 +164,7 @@
                 v-model="quickfillhbso"
                 label="Quick-Fill HBSO"
                 placeholder="DSFB2106A04"
+                :disabled="!('program_run' in course.writeable) || !('program_number' in course.writeable)"
               />
             </v-col>
           </v-row>
@@ -167,12 +174,14 @@
                 v-model="course.program_run"
                 label="Program Run"
                 placeholder="e.g., 2T2021"
+                :disabled="!('program_run' in course.writeable)"
               />
             </v-col><v-col class="col-3">
               <v-text-field
                 v-model="course.program_code"
                 label="Program Number"
                 placeholder="e.g., AA123x"
+                :disabled="!('program_code' in course.writeable)"
               />
             </v-col>
             <v-col class="col-6">
@@ -181,6 +190,7 @@
                 label="Run ID"
                 placeholder="e.g., HarvardX/AA123x/2T2021"
                 hint="(Wave ID for HBSO. Course ID for edX)"
+                :disabled="!('program_id' in course.writeable)"
               />
             </v-col>
           </v-row>
@@ -208,7 +218,7 @@
                       :value="launchDateDisplay"
                       :rules="dateAfterRule"
                       clearable
-                      :disabled="course.fuzzy_launch_date !== null && course.fuzzy_launch_date.length > 0"
+                      :disabled="!('launch_date' in course.writeable) || course.fuzzy_launch_date !== null && course.fuzzy_launch_date.length > 0"
                       v-on="on"
                       @click:clear="course.launch_date = ''"
                       @change="launchTxtUpdate"
@@ -241,7 +251,7 @@
                       :value="endDateDisplay"
                       :rules="dateBeforeRule"
                       clearable
-                      :disabled="course.fuzzy_launch_date !== null && course.fuzzy_launch_date.length > 0"
+                      :disabled="!('end_date' in course.writeable) || course.fuzzy_launch_date !== null && course.fuzzy_launch_date.length > 0"
                       v-on="on"
                       @click:clear="course.end_date = ''"
                       @change="endTxtUpdate"
@@ -259,7 +269,7 @@
               <v-text-field
                 v-model="course.fuzzy_launch_date"
                 label="Approximate Launch & End Date"
-                :disabled="course.launch_date !== null && (course.launch_date.length > 0 || course.end_date.length > 0)"
+                :disabled="!('launch_date' in course.writeable) || !('end_date' in course.writeable) || course.launch_date !== null && (course.launch_date.length > 0 || course.end_date.length > 0)"
                 clearable
               />
             </v-col>
@@ -285,6 +295,7 @@
                       :value="marketingDateDisplay"
                       clearable
                       :rules="dateRules"
+                      :disabled="!('marketing_launch_date' in course.writeable)"
                       v-on="on"
                       @click:clear="course.marketing_launch_date = ''"
                       @change="marketingTxtUpdate"
@@ -318,6 +329,7 @@
                       :value="appOpenDateDisplay"
                       clearable
                       :rules="applicationDateAfterRule"
+                      :disabled="!('application_open_date' in course.writeable)"
                       v-on="on"
                       @click:clear="course.application_open_date = ''"
                       @change="appOpenTxtUpdate"
@@ -351,6 +363,7 @@
                       :value="appCloseDateDisplay"
                       clearable
                       :rules="applicationDateBeforeRule"
+                      :disabled="!('application_close_date' in course.writeable)"
                       v-on="on"
                       @click:clear="course.application_close_date = ''"
                       @change="appCloseTxtUpdate"
@@ -386,6 +399,7 @@
                       :value="enrollmentCutOffDateDisplay"
                       clearable
                       :rules="dateRules"
+                      :disabled="!('enrollment_date' in course.writeable)"
                       v-on="on"
                       @click:clear="course.enrollment_date = ''"
                       @change="enrollmentTxtUpdate"
@@ -419,6 +433,7 @@
                       :value="IDVCutOffDateDisplay"
                       clearable
                       :rules="dateRules"
+                      :disabled="!('cert_enrollment_date' in course.writeable)"
                       v-on="on"
                       @click:clear="course.cert_enrollment_date = ''"
                       @change="certEnrollmentTxtUpdate"
@@ -452,6 +467,7 @@
                       :value="sowDateDisplay"
                       clearable
                       :rules="dateRules"
+                      :disabled="!('sow_approval_date' in course.writeable)"
                       v-on="on"
                       @click:clear="course.sow_approval_date = ''"
                       @change="sowTxtUpdate"
@@ -474,6 +490,7 @@
               <v-checkbox
                 v-model="course.cert_available"
                 label="Certificate Available"
+                :disabled="!('cert_available' in course.writeable)"
               />
             </v-col>
             <v-col class="col-3">
@@ -481,7 +498,7 @@
                 v-model="course.cert_price"
                 number
                 label="Certificate Price"
-                :disabled="!course.cert_available"
+                :disabled="!course.cert_available || !('cert_price' in course.writeable)"
               />
             </v-col>
             <v-col class="col-3">
@@ -489,7 +506,7 @@
                 v-model="course.cert_rate_to_certify"
                 type="number"
                 label="Rate to Certify"
-                :disabled="!course.cert_available"
+                :disabled="!course.cert_available || !('cert_rate_to_certify' in course.writeable)"
                 oninput="this.value = Math.round(this.value)"
                 :rules="posIntRules"
               />
@@ -503,19 +520,21 @@
               <v-checkbox
                 v-model="course.self_paced"
                 label="Self-Paced"
+                :disabled="!('self_paced' in course.writeable)"
               />
             </v-col>
             <v-col class="col-4">
               <v-checkbox
                 v-model="course.faculty_agreement_signed"
                 label="Faculty Agreement Signed"
+                :disabled="!('faculty_agreement_signed' in course.writeable)"
               />
             </v-col>
             <v-col class="col-5">
               <v-checkbox
                 v-model="course.videos_archived"
                 label="Course Videos Archived"
-                disabled
+                :disabled="!('videos_archived' in course.writeable)"
               />
             </v-col>
           </v-row>
@@ -526,6 +545,7 @@
                 label="Estimated hrs per week (Min)"
                 type="number"
                 :rules="lessThanMax"
+                :disabled="!('estimated_effort_min' in course.writeable)"
                 oninput="if (this.value < 1) {this.value = 0}"
                 required
                 @input="triggerEstimatedEffortValidation"
@@ -539,6 +559,7 @@
                 :rules="greaterThanMin"
                 oninput="if (this.value < 1) {this.value = 0}"
                 required
+                :disabled="!('estimated_effort_max' in course.writeable)"
               />
             </v-col>
             <v-col class="col-4">
@@ -548,6 +569,7 @@
                 type="number"
                 :rules="posIntRules"
                 required
+                :disabled="!('duration_weeks' in course.writeable)"
               />
             </v-col>
           </v-row>
@@ -557,6 +579,7 @@
                 v-model="course.enrollment_type"
                 :items="enrollmenttype"
                 label="Enrollment Type"
+                :disabled="!('enrollment_type' in course.writeable)"
               />
             </v-col>
             <v-col class="col-4">
@@ -564,6 +587,7 @@
                 v-model="course.delivery_platform"
                 :items="deliveryplatform"
                 label="Delivery Platform"
+                :disabled="!('delivery_platform' in course.writeable)"
                 @input="changeDeliveryPlatform"
               />
             </v-col>
@@ -572,6 +596,7 @@
                 v-model="course.technical_platform"
                 :items="technicalplatform"
                 label="Technical Platform"
+                :disabled="!('technical_platform' in course.writeable)"
               />
             </v-col>
           </v-row>
@@ -582,6 +607,7 @@
                 :items="school"
                 label="Affiliation"
                 multiple
+                :disabled="!('sponsoring_school' in course.writeable)"
               />
             </v-col>
           </v-row>
@@ -592,6 +618,7 @@
                 :items="vpaldiscipline"
                 label="VPAL Disciplines (Marketing)"
                 multiple
+                :disabled="!('vpal_discipline' in course.writeable)"
               />
             </v-col>
             <v-col class="col-6">
@@ -602,6 +629,7 @@
                 no-data-text="No Disciplines for chosen Delivery Platform"
                 multiple
                 :value="platform_discipline_pk"
+                :disabled="!('platform_discipline' in course.writeable)"
                 @input="onPlatformDisciplineInput"
               />
             </v-col>
@@ -614,12 +642,14 @@
               <v-text-field
                 v-model="course.enrollment_page_url"
                 label="Enrollment Page Url"
+                :disabled="!('enrollment_page_url' in course.writeable)"
               />
             </v-col>
             <v-col class="col-12">
               <v-text-field
                 v-model="course.public_url"
                 label="Public Url"
+                :disabled="!('public_url' in course.writeable)"
               />
             </v-col>
           </v-row>
@@ -650,6 +680,7 @@
                         :items="role"
                         :filter="filter"
                         label="Role"
+                        :disabled="!('team' in course.writeable)"
                       />
                     </td>
                     <td>
@@ -657,6 +688,7 @@
                         <v-row>
                           <v-col class="col-12">
                             <v-btn
+                              :disabled="!('team' in course.writeable)"
                               @click="deletePerson(item)"
                             >
                               <v-icon
@@ -679,6 +711,7 @@
                       :filter="filter"
                       item-text="name"
                       label="Add Person"
+                      :disabled="!('team' in course.writeable)"
                     />
                   </td>
                   <td class="pa-5">
@@ -687,11 +720,13 @@
                       :items="role"
                       :filter="filter"
                       label="Add role"
+                      :disabled="!('team' in course.writeable)"
                     />
                   </td>
                   <td class="pa-5 d-flex justify-center">
                     <v-btn
                       color="primary"
+                      :disabled="!('team' in course.writeable)"
                       @click="addTeam"
                     >
                       Add

--- a/hxydra/src/components/EditForm.vue
+++ b/hxydra/src/components/EditForm.vue
@@ -49,6 +49,7 @@
               label="Project Name"
               :rules="titleLength"
               required
+              :disabled="!('title' in course.writeable)"
             />
           </v-col>
         </v-row>
@@ -59,6 +60,7 @@
               label="Common Project Name"
               :rules="commonNameLength"
               required
+              :disabled="!('common_name' in course.writeable)"
             />
           </v-col>
           <v-col class="col-3">

--- a/hxydra/src/components/EditForm.vue
+++ b/hxydra/src/components/EditForm.vue
@@ -532,9 +532,9 @@
             </v-col>
             <v-col class="col-5">
               <v-checkbox
-                v-model="course.videos_archived"
+                v-model="course.video_archived"
                 label="Course Videos Archived"
-                :disabled="!('videos_archived' in course.writeable)"
+                :disabled="!('video_archived' in course.writeable)"
               />
             </v-col>
           </v-row>

--- a/hxydra/src/components/EditForm.vue
+++ b/hxydra/src/components/EditForm.vue
@@ -511,9 +511,9 @@
             </v-col>
             <v-col class="col-5">
               <v-checkbox
-                disabled
                 v-model="course.videos_archived"
                 label="Course Videos Archived"
+                disabled
               />
             </v-col>
           </v-row>

--- a/hxydra/src/components/EditForm.vue
+++ b/hxydra/src/components/EditForm.vue
@@ -156,7 +156,7 @@
                 v-model="quickfilledx"
                 label="Quick-Fill edX"
                 placeholder="course-v1:HarvardX+PH211x+1T2021"
-                :disabled="!('program_run' in course.writeable) || !('program_number' in course.writeable)"
+                :disabled="!('program_run' in course.writeable) || !('program_code' in course.writeable) || !('program_id' in course.writeable)"
               />
             </v-col>
             <v-col class="col-6">
@@ -164,7 +164,7 @@
                 v-model="quickfillhbso"
                 label="Quick-Fill HBSO"
                 placeholder="DSFB2106A04"
-                :disabled="!('program_run' in course.writeable) || !('program_number' in course.writeable)"
+                :disabled="!('program_run' in course.writeable) || !('program_code' in course.writeable) || !('program_id' in course.writeable)"
               />
             </v-col>
           </v-row>

--- a/hxydra/src/components/NavMenu.vue
+++ b/hxydra/src/components/NavMenu.vue
@@ -57,7 +57,7 @@
       <span>Unique Projects</span>
     </v-tooltip>
     <v-tooltip
-      v-if="hasWritePerms"
+      v-if="hasWritePerms.create"
       bottom
     >
       <template #activator="{on, attrs}">
@@ -100,7 +100,7 @@
       <span>Download Reports</span>
     </v-tooltip>
     <v-tooltip 
-      v-if="hasWritePerms"
+      v-if="hasWritePerms.admin"
       bottom
     >
       <template #activator="{on, attrs}">
@@ -133,8 +133,16 @@
       type: String
     },
     hasWritePerms: {
-      default: false,
-      type: Boolean
+      default () {
+        return {
+          admin: false,
+          read: true,
+          update: false,
+          create: false,
+          delete: false
+        }
+      },
+      type: Object
     },
     pageTitle: {
       default: "",

--- a/hxydra/src/components/NavMenu.vue
+++ b/hxydra/src/components/NavMenu.vue
@@ -1,0 +1,147 @@
+<template>
+  <v-app-bar
+    app
+    color="#483682"
+    dark
+  >
+    <div class="d-flex align-center">
+      <v-btn
+        class="text-h4 font-weight-bold text-none"
+        text
+        href="/kondo_projects/"
+      >
+        Kondo
+      </v-btn><span class="text-h7">{{ pageTitle }}</span>
+    </div>
+
+    <v-spacer />
+
+    <v-tooltip bottom>
+      <template #activator="{on, attrs}">
+        <v-btn
+          class="mx-1"
+          fab
+          dark
+          small
+          href="/kondo_projects"
+          color="#483682 accent"
+          :disabled="currentPage == 'projects'"
+          v-bind="attrs"
+          v-on="on"
+        >
+          <v-icon>
+            mdi-home
+          </v-icon>
+        </v-btn>
+      </template>
+      <span>Project List</span>
+    </v-tooltip>
+    <v-tooltip bottom>
+      <template #activator="{on, attrs}">
+        <v-btn
+          class="mx-1"
+          fab
+          dark
+          small
+          href="/kondo_uniqueprojects"
+          color="#483682 accent"
+          :disabled="currentPage == 'unique'"
+          v-bind="attrs"
+          v-on="on"
+        >
+          <v-icon>
+            mdi-snowflake
+          </v-icon>
+        </v-btn>
+      </template>
+      <span>Unique Projects</span>
+    </v-tooltip>
+    <v-tooltip
+      v-if="hasWritePerms"
+      bottom
+    >
+      <template #activator="{on, attrs}">
+        <v-btn
+          class="mx-1"
+          fab
+          dark
+          small
+          href="/kondo_create"
+          color="#483682 accent"
+          :disabled="currentPage == 'create'"
+          v-bind="attrs"
+          v-on="on"
+        >
+          <v-icon>
+            mdi-plus
+          </v-icon>
+        </v-btn>
+      </template>
+      <span>Create New Project</span>
+    </v-tooltip>
+    <v-tooltip bottom>
+      <template #activator="{on, attrs}">
+        <v-btn
+          class="mx-1"
+          fab
+          dark
+          small
+          href="/kondo_reportlist/"
+          color="#483682 accent"
+          :disabled="currentPage == 'reports'"
+          v-bind="attrs"
+          v-on="on"
+        >
+          <v-icon>
+            mdi-download
+          </v-icon>
+        </v-btn>
+      </template>
+      <span>Download Reports</span>
+    </v-tooltip>
+    <v-tooltip 
+      v-if="hasWritePerms"
+      bottom
+    >
+      <template #activator="{on, attrs}">
+        <v-btn
+          class="mx-1"
+          fab
+          dark
+          small
+          href="/kondo_choice/"
+          color="#483682 accent"
+          :disabled="currentPage == 'choice'"
+          v-bind="attrs"
+          v-on="on"
+        >
+          <v-icon>
+            mdi-cog
+          </v-icon>
+        </v-btn>
+      </template>
+      <span>Config Dropdown Lists</span>
+    </v-tooltip>
+  </v-app-bar>
+</template>
+<script>
+  export default {
+  name: 'NavMenu',
+  props: {
+    currentPage: {
+      default: "",
+      type: String
+    },
+    hasWritePerms: {
+      default: false,
+      type: Boolean
+    },
+    pageTitle: {
+      default: "",
+      type: String
+    }
+  },
+  data: () => ({
+  }),
+  }
+</script>

--- a/hxydra/src/components/NavMenu.vue
+++ b/hxydra/src/components/NavMenu.vue
@@ -57,7 +57,7 @@
       <span>Unique Projects</span>
     </v-tooltip>
     <v-tooltip
-      v-if="hasWritePerms.create"
+      v-if="hasWritePerms.create || hasWritePerms.admin"
       bottom
     >
       <template #activator="{on, attrs}">

--- a/hxydra/src/components/ProjectsList.vue
+++ b/hxydra/src/components/ProjectsList.vue
@@ -350,7 +350,7 @@
         }
         await axios.get(
           self.api_projects_url + item.nickname
-          + '/'
+          + '/?permission=true'
         )
           .then(data => this.selected = data.data)
           .catch(function(e) {

--- a/hxydra/src/components/ProjectsList.vue
+++ b/hxydra/src/components/ProjectsList.vue
@@ -49,28 +49,28 @@
           </v-btn>
           <v-spacer />
           <v-btn
-            v-if="write_perm"
+            v-if="write_perm.create"
             class="mr-3"
             @click="createNewSequence(rowItem)"
           >
             New Sequence
           </v-btn>
           <v-btn
-            v-if="write_perm"
+            v-if="write_perm.create"
             class="mr-3"
             @click="createNewVersion(rowItem)"
           >
             New Version
           </v-btn>
           <v-btn
-            v-if="write_perm"
+            v-if="write_perm.create"
             class="mr-3"
             @click="createNewRerun(rowItem)"
           >
             New Run
           </v-btn>
           <v-btn
-            v-if="write_perm"
+            v-if="write_perm.delete"
             @click="deleteItem(rowItem)"
           >
             <v-icon
@@ -147,7 +147,7 @@
               <v-container>
                 <v-row>
                   <v-col
-                    v-if="write_perm"
+                    v-if="write_perm.update"
                     class="col-6"
                   >
                     <v-icon
@@ -226,19 +226,21 @@
   import EditForm from './EditForm'
   import DetailView from './DetailView'
   import axios from 'axios'
-  let perms = false
-  try {
-    const cookie = document.cookie
-    if (typeof(cookie) !== "undefined") {
-      let cookie_split = cookie.split(';').map(x => x.split('='))
-      let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
-      if (perm_cookie_val.length > 0) {
-        perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
-      }
-    }
-  } catch {
-    perms = false
-  }
+  import getPermissionsFromCookie from '../resources/permissions';
+
+  // let perms = false
+  // try {
+  //   const cookie = document.cookie
+  //   if (typeof(cookie) !== "undefined") {
+  //     let cookie_split = cookie.split(';').map(x => x.split('='))
+  //     let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
+  //     if (perm_cookie_val.length > 0) {
+  //       perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
+  //     }
+  //   }
+  // } catch {
+  //   perms = false
+  // }
   export default {
     name: 'ProjectsList',
     components: {
@@ -253,7 +255,7 @@
       rowItem: undefined,
       errorMessage: "",
       errorBox: false,
-      write_perm: perms,
+      write_perm: getPermissionsFromCookie(),
       debugDialog: false,
       newProject: undefined,
       headers: [{

--- a/hxydra/src/components/ReportView.vue
+++ b/hxydra/src/components/ReportView.vue
@@ -201,6 +201,7 @@
   .no-padding, th {
     padding-left: 10px!important;
     padding-right: 5px!important;
+    min-width: 86px!important;
   }
   .spin {
     animation-name: spin;

--- a/hxydra/src/components/UniqueProjectsList.vue
+++ b/hxydra/src/components/UniqueProjectsList.vue
@@ -3,7 +3,7 @@
     <div class="text-center">
       <v-snackbar
         v-model="result_snackbar"
-        :multi-line="multiLine"
+        :multi-line="true"
         :color="result_color"
         centered
       >
@@ -221,6 +221,7 @@
       detail: false,
       editing: false,
       selected: undefined,
+      result_color: "white",
     }),
     mounted() {
       this.getUniqueProjects();

--- a/hxydra/src/components/UniqueProjectsList.vue
+++ b/hxydra/src/components/UniqueProjectsList.vue
@@ -60,6 +60,7 @@
               <v-checkbox
                 v-model="item.video_archived"
                 @change="archiveChanged(item)"
+                :disabled="!('video_archived' in item.writeable)"
               />
             </span>
           </template>

--- a/hxydra/src/components/UniqueProjectsList.vue
+++ b/hxydra/src/components/UniqueProjectsList.vue
@@ -177,16 +177,11 @@
         cellClass: 'no-padding'
       },],
       projectheaders: [{
-        text: 'Videos Archived',
-        sortable: false,
-        value: 'video_archived',
-        cellClass: 'no-padding'
-      },{
         text: 'Prefix',
         sortable: true,
         value: 'prefix',
         cellClass: 'no-padding'
-      },{
+      }, {
         text: 'Seq',
         sortable: true,
         value: 'sequence',
@@ -211,7 +206,12 @@
         sortable: true,
         value: 'title',
         cellClass: 'no-padding'
-      }],
+      }, {
+        text: 'Videos Archived',
+        sortable: false,
+        value: 'video_archived',
+        cellClass: 'no-padding'
+      },],
       api_projects_url: process.env.VUE_APP_KONDO_API_URL,
       api_uniqueprojects_url: process.env.VUE_APP_KONDO_API_URL + 'projectps/',
       uniqueprojects: [],

--- a/hxydra/src/components/UniqueProjectsList.vue
+++ b/hxydra/src/components/UniqueProjectsList.vue
@@ -1,0 +1,103 @@
+<template>
+  <v-container>
+    <v-card>
+      <v-card-title>
+        Unique Projects
+      </v-card-title>
+      <v-data-table
+        :headers="headers"
+        :items="projects"
+        :items-per-page="50"
+        class="projects-1"
+        :search="search"
+        :custom-filter="filter"
+        :footer-props="{
+          showFirstLastPage: true,
+          firstIcon: 'mdi-arrow-collapse-left',
+          lastIcon: 'mdi-arrow-collapse-right',
+          itemsPerPageOptions: [10, 20, 50, 100, -1]
+        }
+        "
+      ></v-data-table>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+  import axios from 'axios'
+  let perms = false
+  try {
+    const cookie = document.cookie
+    if (typeof(cookie) !== "undefined") {
+      let cookie_split = cookie.split(';').map(x => x.split('='))
+      let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
+      if (perm_cookie_val.length > 0) {
+        perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
+      }
+    }
+  } catch {
+    perms = false
+  }
+  export default {
+    name: 'UniqueProjectsList',
+    components: {
+    },
+    data: () => ({
+      search: '',
+      headers: [{
+        text: 'Prefix',
+        sortable: true,
+        value: 'prefix',
+        width: '10%'
+      },{
+        text: 'Sequence',
+        sortable: true,
+        value: 'sequence',
+        width: '5%'
+      },{
+        text: 'Title',
+        sortable: true,
+        value: 'title',
+        width: '75%'
+      },{
+        text: 'Actions',
+        sortable: false,
+        align: 'center',
+        width: '10%'
+      },],
+      api_uniqueprojects_url: process.env.VUE_APP_KONDO_API_URL + 'projectps/',
+      projects: [],
+    }),
+    mounted() {
+      this.getProjects();
+    },
+    methods: {
+      filter (value, search) {
+        if (value && search) {
+          if (typeof(value) !== "undefined") {
+            return value.toString().toLocaleUpperCase().indexOf(search.toLocaleUpperCase()) > -1
+          }
+        }
+        return false
+      },
+      async getProjects () {
+        const self = this
+        if (!axios) {
+          return
+        }
+        await axios.get(
+          self.api_uniqueprojects_url
+        )
+          .then(data => {
+            self.projects = data.data
+          })
+          .catch(function(e) {
+            self.errorBox = true
+            self.errorMessage = "API could not be reached. Using fake data."
+            console.log(e)
+          });
+        
+      },
+    }
+  }
+</script>

--- a/hxydra/src/components/UniqueProjectsList.vue
+++ b/hxydra/src/components/UniqueProjectsList.vue
@@ -27,7 +27,16 @@
       style="background: white"
     >
       <v-card v-if="selected">
-        <v-card-title>{{ selected.prefix }} + {{ selected.sequence }} Projects</v-card-title>
+        <v-card-title>
+          {{ selected.prefix }} + {{ selected.sequence }} Projects
+          <v-spacer />
+          <v-btn
+            class="ma-2"
+            @click="detail = false"
+          >
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-card-title>
         <v-data-table
           :headers="projectheaders"
           :items="selected.projects"
@@ -103,7 +112,7 @@
               <v-container>
                 <v-row>
                   <v-col
-                    v-if="write_perm"
+                    v-if="write_perms.update"
                     class="col-6"
                   >
                     <v-icon
@@ -134,20 +143,8 @@
 
 <script>
   import axios from 'axios'
-  let perms = false
-  try {
-    const cookie = document.cookie
-    if (typeof(cookie) !== "undefined") {
-      let cookie_split = cookie.split(';').map(x => x.split('='))
-      let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
-      perms = perm_cookie_val.length > 0
-      // if (perm_cookie_val.length > 0) {
-      //   perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
-      // }
-    }
-  } catch {
-    perms = false
-  }
+  import getPermissionsFromCookie from '../resources/permissions';
+
   export default {
     name: 'UniqueProjectsList',
     components: {
@@ -217,7 +214,7 @@
       api_projects_url: process.env.VUE_APP_KONDO_API_URL,
       api_uniqueprojects_url: process.env.VUE_APP_KONDO_API_URL + 'projectps/',
       uniqueprojects: [],
-      write_perm: perms,
+      write_perms: getPermissionsFromCookie(),
       detail: false,
       editing: false,
       selected: undefined,

--- a/hxydra/src/pages/kondo_choice/App.vue
+++ b/hxydra/src/pages/kondo_choice/App.vue
@@ -2,7 +2,7 @@
   <v-app>
     <NavMenu
       current-page="choice"
-      has-write-permissions="write_perms"
+      :has-write-perms="write_perms"
       page-title="Configure Lists" 
     />
     <v-main>
@@ -14,20 +14,8 @@
 <script>
 import KondoChoice from '../../components/Choice';
 import NavMenu from '../../components/NavMenu';
+import getPermissionsFromCookie from '../../resources/permissions';
 
-let perms = false
-try {
-  const cookie = document.cookie
-  if (typeof(cookie) !== "undefined") {
-    let cookie_split = cookie.split(';').map(x => x.split('='))
-    let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
-    if (perm_cookie_val.length > 0) {
-      perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
-    }
-  }
-} catch {
-  perms = false
-}
 export default {
   name: 'App',
 
@@ -37,7 +25,7 @@ export default {
   },
 
   data: () => ({
-    write_perm: perms
+    write_perms: getPermissionsFromCookie()
   }),
 };
 </script>

--- a/hxydra/src/pages/kondo_choice/App.vue
+++ b/hxydra/src/pages/kondo_choice/App.vue
@@ -1,105 +1,10 @@
 <template>
   <v-app>
-    <v-app-bar
-      app
-      color="#483682"
-      dark
-    >
-      <div class="d-flex align-center">
-        <v-btn
-          class="text-h4 font-weight-bold text-none"
-          text
-          href="/kondo_projects/"
-        >
-          Kondo
-        </v-btn><span class="text-h7">Configure Lists</span>
-      </div>
-
-      <v-spacer />
-
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_projects"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-home
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Project List</span>
-      </v-tooltip>
-      <v-tooltip
-        v-if="write_perm"
-        bottom
-      >
-        <template #activator="{on, attrs}">
-          <v-btn
-            
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_create"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-plus
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Create New Project</span>
-      </v-tooltip>
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_reportlist/"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-download
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Download Reports</span>
-      </v-tooltip>
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_choice/"
-            color="#483682 accent"
-            v-bind="attrs"
-            disabled
-            v-on="on"
-          >
-            <v-icon>
-              mdi-cog
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Config Dropdown Lists</span>
-      </v-tooltip>
-    </v-app-bar>
-
+    <NavMenu
+      current-page="choice"
+      has-write-permissions="write_perms"
+      page-title="Configure Lists" 
+    />
     <v-main>
       <KondoChoice />
     </v-main>
@@ -108,6 +13,8 @@
 
 <script>
 import KondoChoice from '../../components/Choice';
+import NavMenu from '../../components/NavMenu';
+
 let perms = false
 try {
   const cookie = document.cookie
@@ -126,6 +33,7 @@ export default {
 
   components: {
     KondoChoice,
+    NavMenu
   },
 
   data: () => ({

--- a/hxydra/src/pages/kondo_create/App.vue
+++ b/hxydra/src/pages/kondo_create/App.vue
@@ -2,7 +2,7 @@
   <v-app>
     <NavMenu
       current-page="create"
-      has-write-permissions="write_perms"
+      :has-write-perms="write_perms"
       page-title="Create New Project"
     />
     <v-main>
@@ -14,20 +14,7 @@
 <script>
 import CreateForm from '../../components/CreateForm';
 import NavMenu from '../../components/NavMenu';
-
-let perms = false
-try {
-  const cookie = document.cookie
-  if (typeof(cookie) !== "undefined") {
-    let cookie_split = cookie.split(';').map(x => x.split('='))
-    let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
-    if (perm_cookie_val.length > 0) {
-      perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
-    }
-  }
-} catch {
-  perms = false
-}
+import getPermissionsFromCookie from '../../resources/permissions';
 
 export default {
   name: 'App',
@@ -38,7 +25,7 @@ export default {
   },
 
   data: () => ({
-    write_perms:perms
+    write_perms: getPermissionsFromCookie()
   }),
 };
 </script>

--- a/hxydra/src/pages/kondo_create/App.vue
+++ b/hxydra/src/pages/kondo_create/App.vue
@@ -1,103 +1,10 @@
 <template>
   <v-app>
-    <v-app-bar
-      app
-      color="#483682"
-      dark
-    >
-      <div class="d-flex align-center">
-        <v-btn
-          class="text-h4 font-weight-bold text-none"
-          text
-          href="/kondo_projects/"
-        >
-          Kondo
-        </v-btn><span class="text-h7">Create New Project</span>
-      </div>
-      <v-spacer />
-
-      
-
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_projects"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-home
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Project List</span>
-      </v-tooltip>
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_create"
-            color="#483682 accent"
-            v-bind="attrs"
-            disabled
-            v-on="on"
-          >
-            <v-icon>
-              mdi-plus
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Create New Project</span>
-      </v-tooltip>
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_reportlist/"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-download
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Download Reports</span>
-      </v-tooltip>
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_choice/"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-cog
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Config Dropdown Lists</span>
-      </v-tooltip>
-    </v-app-bar>
-
+    <NavMenu
+      current-page="create"
+      has-write-permissions="write_perms"
+      page-title="Create New Project"
+    />
     <v-main>
       <CreateForm />
     </v-main>
@@ -106,16 +13,32 @@
 
 <script>
 import CreateForm from '../../components/CreateForm';
+import NavMenu from '../../components/NavMenu';
+
+let perms = false
+try {
+  const cookie = document.cookie
+  if (typeof(cookie) !== "undefined") {
+    let cookie_split = cookie.split(';').map(x => x.split('='))
+    let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
+    if (perm_cookie_val.length > 0) {
+      perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
+    }
+  }
+} catch {
+  perms = false
+}
 
 export default {
   name: 'App',
-
+  
   components: {
     CreateForm,
+    NavMenu
   },
 
   data: () => ({
-    //
+    write_perms:perms
   }),
 };
 </script>

--- a/hxydra/src/pages/kondo_projects/App.vue
+++ b/hxydra/src/pages/kondo_projects/App.vue
@@ -2,7 +2,7 @@
   <v-app>
     <NavMenu
       current-page="projects"
-      has-write-permissions="write_perms"
+      :has-write-perms="write_perms"
       page-title=""
     />
     <v-main>
@@ -14,19 +14,8 @@
 <script>
 import ProjectsList from '../../components/ProjectsList';
 import NavMenu from '../../components/NavMenu';
-let perms = false
-try {
-  const cookie = document.cookie
-  if (typeof(cookie) !== "undefined") {
-    let cookie_split = cookie.split(';').map(x => x.split('='))
-    let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
-    if (perm_cookie_val.length > 0) {
-      perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
-    }
-  }
-} catch {
-  perms = false
-}
+import getPermissionsFromCookie from '../../resources/permissions';
+
 export default {
   name: 'App',
 
@@ -36,7 +25,7 @@ export default {
   },
 
   data: () => ({
-    write_perm: perms
+    write_perms: getPermissionsFromCookie()
   }),
 };
 </script>

--- a/hxydra/src/pages/kondo_projects/App.vue
+++ b/hxydra/src/pages/kondo_projects/App.vue
@@ -1,106 +1,10 @@
 <template>
   <v-app>
-    <v-app-bar
-      app
-      color="#483682"
-      dark
-    >
-      <div class="d-flex align-center">
-        <v-btn
-          class="text-h4 font-weight-bold text-none"
-          text
-        >
-          Kondo
-        </v-btn>
-      </div>
-
-      <v-spacer />
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_projects"
-            color="#483682 accent"
-            v-bind="attrs"
-            disabled
-            v-on="on"
-          >
-            <v-icon>
-              mdi-home
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Home</span>
-      </v-tooltip>
-      <v-tooltip
-        v-if="write_perm"
-        bottom
-      >
-        <template #activator="{on, attrs}">
-          <v-btn
-            
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_create"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-plus
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Create New Project</span>
-      </v-tooltip>
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_reportlist/"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-download
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Download Reports</span>
-      </v-tooltip>
-      <v-tooltip
-        v-if="write_perm"
-        bottom
-      >
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_choice/"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-cog
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Config Dropdown Lists</span>
-      </v-tooltip>
-    </v-app-bar>
-
+    <NavMenu
+      current-page="projects"
+      has-write-permissions="write_perms"
+      page-title=""
+    />
     <v-main>
       <ProjectsList />
     </v-main>
@@ -109,6 +13,7 @@
 
 <script>
 import ProjectsList from '../../components/ProjectsList';
+import NavMenu from '../../components/NavMenu';
 let perms = false
 try {
   const cookie = document.cookie
@@ -127,6 +32,7 @@ export default {
 
   components: {
     ProjectsList,
+    NavMenu
   },
 
   data: () => ({

--- a/hxydra/src/pages/kondo_reportlist/App.vue
+++ b/hxydra/src/pages/kondo_reportlist/App.vue
@@ -1,105 +1,10 @@
 <template>
   <v-app>
-    <v-app-bar
-      app
-      color="#483682"
-      dark
-    >
-      <div class="d-flex align-center">
-        <v-btn
-          class="text-h4 font-weight-bold text-none"
-          text
-          href="/kondo_projects/"
-        >
-          Kondo
-        </v-btn><span class="text-h7">Reports</span>
-      </div>
-      <v-spacer />
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_projects"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-home
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Project List</span>
-      </v-tooltip>
-      <v-tooltip
-        v-if="write_perm"
-        bottom
-      >
-        <template #activator="{on, attrs}">
-          <v-btn
-            
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_create"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-plus
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Create New Project</span>
-      </v-tooltip>
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_reportlist/"
-            color="#483682 accent"
-            v-bind="attrs"
-            disabled
-            v-on="on"
-          >
-            <v-icon>
-              mdi-download
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Download Reports</span>
-      </v-tooltip>
-      <v-tooltip
-        v-if="write_perm"
-        bottom
-      >
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_choice/"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-cog
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Config Dropdown Lists</span>
-      </v-tooltip>
-    </v-app-bar>
+    <NavMenu
+      current-page="reports"
+      has-write-permissions="write_perms"
+      page-title="Reports"
+    />
 
     <v-main>
       <ReportList />
@@ -110,6 +15,8 @@
 <script>
 
 import ReportList from '../../components/ReportList';
+import NavMenu from '../../components/NavMenu';
+
 let perms = false
 try {
   const cookie = document.cookie
@@ -127,7 +34,8 @@ export default {
   name: 'ReportsList',
 
   components: {
-    ReportList
+    ReportList,
+    NavMenu
   },
 
   data: () => ({

--- a/hxydra/src/pages/kondo_reportlist/App.vue
+++ b/hxydra/src/pages/kondo_reportlist/App.vue
@@ -2,7 +2,7 @@
   <v-app>
     <NavMenu
       current-page="reports"
-      has-write-permissions="write_perms"
+      :has-write-perms="write_perms"
       page-title="Reports"
     />
 
@@ -16,20 +16,8 @@
 
 import ReportList from '../../components/ReportList';
 import NavMenu from '../../components/NavMenu';
+import getPermissionsFromCookie from '../../resources/permissions';
 
-let perms = false
-try {
-  const cookie = document.cookie
-  if (typeof(cookie) !== "undefined") {
-    let cookie_split = cookie.split(';').map(x => x.split('='))
-    let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
-    if (perm_cookie_val.length > 0) {
-      perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
-    }
-  }
-} catch {
-  perms = false
-}
 export default {
   name: 'ReportsList',
 
@@ -39,7 +27,7 @@ export default {
   },
 
   data: () => ({
-    write_perm: perms
+    write_perms: getPermissionsFromCookie()
   }),
 };
 </script>

--- a/hxydra/src/pages/kondo_reportview/App.vue
+++ b/hxydra/src/pages/kondo_reportview/App.vue
@@ -2,7 +2,7 @@
   <v-app>
     <NavMenu
       current-page=""
-      has-write-permissions="write_perms"
+      :has-write-perms="write_perms"
       page-title="Report View"
     />
 
@@ -16,20 +16,8 @@
 
 import ReportView from '../../components/ReportView';
 import NavMenu from '../../components/NavMenu.vue';
+import getPermissionsFromCookie from '../../resources/permissions';
 
-let perms = false
-try {
-  const cookie = document.cookie
-  if (typeof(cookie) !== "undefined") {
-    let cookie_split = cookie.split(';').map(x => x.split('='))
-    let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
-    if (perm_cookie_val.length > 0) {
-      perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
-    }
-  }
-} catch {
-  perms = false
-}
 export default {
   name: 'ReportTableView',
 
@@ -39,7 +27,7 @@ export default {
   },
 
   data: () => ({
-    write_perm: perms
+    write_perms: getPermissionsFromCookie()
   }),
 };
 </script>

--- a/hxydra/src/pages/kondo_reportview/App.vue
+++ b/hxydra/src/pages/kondo_reportview/App.vue
@@ -1,104 +1,10 @@
 <template>
   <v-app>
-    <v-app-bar
-      app
-      color="#483682"
-      dark
-    >
-      <div class="d-flex align-center">
-        <v-btn
-          class="text-h4 font-weight-bold text-none"
-          text
-          href="/kondo_projects/"
-        >
-          Kondo
-        </v-btn><span class="text-h7">Report View</span>
-      </div>
-      <v-spacer />
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_projects"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-home
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Project List</span>
-      </v-tooltip>
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_reportlist/"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-download
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Download Reports</span>
-      </v-tooltip>
-      <v-tooltip
-        v-if="write_perm"
-        bottom
-      >
-        <template #activator="{on, attrs}">
-          <v-btn
-            
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_create"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-plus
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Create New Project</span>
-      </v-tooltip>
-      <v-tooltip
-        v-if="write_perm"
-        bottom
-      >
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_choice/"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-cog
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Config Dropdown Lists</span>
-      </v-tooltip>
-    </v-app-bar>
+    <NavMenu
+      current-page=""
+      has-write-permissions="write_perms"
+      page-title="Report View"
+    />
 
     <v-main>
       <ReportView />
@@ -109,6 +15,8 @@
 <script>
 
 import ReportView from '../../components/ReportView';
+import NavMenu from '../../components/NavMenu.vue';
+
 let perms = false
 try {
   const cookie = document.cookie
@@ -126,7 +34,8 @@ export default {
   name: 'ReportTableView',
 
   components: {
-    ReportView
+    ReportView,
+    NavMenu
   },
 
   data: () => ({

--- a/hxydra/src/pages/kondo_uniqueprojects/App.vue
+++ b/hxydra/src/pages/kondo_uniqueprojects/App.vue
@@ -1,0 +1,136 @@
+<template>
+  <v-app>
+    <v-app-bar
+      app
+      color="#483682"
+      dark
+    >
+      <div class="d-flex align-center">
+        <v-btn
+          class="text-h4 font-weight-bold text-none"
+          text
+        >
+          Kondo
+        </v-btn>
+      </div>
+
+      <v-spacer />
+      <v-tooltip bottom>
+        <template #activator="{on, attrs}">
+          <v-btn
+            class="mx-1"
+            fab
+            dark
+            small
+            href="/kondo_projects"
+            color="#483682 accent"
+            v-bind="attrs"
+            disabled
+            v-on="on"
+          >
+            <v-icon>
+              mdi-home
+            </v-icon>
+          </v-btn>
+        </template>
+        <span>Home</span>
+      </v-tooltip>
+      <v-tooltip
+        v-if="write_perm"
+        bottom
+      >
+        <template #activator="{on, attrs}">
+          <v-btn
+            
+            class="mx-1"
+            fab
+            dark
+            small
+            href="/kondo_create"
+            color="#483682 accent"
+            v-bind="attrs"
+            v-on="on"
+          >
+            <v-icon>
+              mdi-plus
+            </v-icon>
+          </v-btn>
+        </template>
+        <span>Create New Project</span>
+      </v-tooltip>
+      <v-tooltip bottom>
+        <template #activator="{on, attrs}">
+          <v-btn
+            class="mx-1"
+            fab
+            dark
+            small
+            href="/kondo_reportlist/"
+            color="#483682 accent"
+            v-bind="attrs"
+            v-on="on"
+          >
+            <v-icon>
+              mdi-download
+            </v-icon>
+          </v-btn>
+        </template>
+        <span>Download Reports</span>
+      </v-tooltip>
+      <v-tooltip
+        v-if="write_perm"
+        bottom
+      >
+        <template #activator="{on, attrs}">
+          <v-btn
+            class="mx-1"
+            fab
+            dark
+            small
+            href="/kondo_choice/"
+            color="#483682 accent"
+            v-bind="attrs"
+            v-on="on"
+          >
+            <v-icon>
+              mdi-cog
+            </v-icon>
+          </v-btn>
+        </template>
+        <span>Config Dropdown Lists</span>
+      </v-tooltip>
+    </v-app-bar>
+
+    <v-main>
+      <UniqueProjectsList />
+    </v-main>
+  </v-app>
+</template>
+
+<script>
+import UniqueProjectsList from '../../components/UniqueProjectsList';
+let perms = false
+try {
+  const cookie = document.cookie
+  if (typeof(cookie) !== "undefined") {
+    let cookie_split = cookie.split(';').map(x => x.split('='))
+    let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
+    if (perm_cookie_val.length > 0) {
+      perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
+    }
+  }
+} catch {
+  perms = false
+}
+export default {
+  name: 'App',
+
+  components: {
+    UniqueProjectsList,
+  },
+
+  data: () => ({
+    write_perm: perms
+  }),
+};
+</script>

--- a/hxydra/src/pages/kondo_uniqueprojects/App.vue
+++ b/hxydra/src/pages/kondo_uniqueprojects/App.vue
@@ -1,106 +1,10 @@
 <template>
   <v-app>
-    <v-app-bar
-      app
-      color="#483682"
-      dark
-    >
-      <div class="d-flex align-center">
-        <v-btn
-          class="text-h4 font-weight-bold text-none"
-          text
-        >
-          Kondo
-        </v-btn>
-      </div>
-
-      <v-spacer />
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_projects"
-            color="#483682 accent"
-            v-bind="attrs"
-            disabled
-            v-on="on"
-          >
-            <v-icon>
-              mdi-home
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Home</span>
-      </v-tooltip>
-      <v-tooltip
-        v-if="write_perm"
-        bottom
-      >
-        <template #activator="{on, attrs}">
-          <v-btn
-            
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_create"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-plus
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Create New Project</span>
-      </v-tooltip>
-      <v-tooltip bottom>
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_reportlist/"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-download
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Download Reports</span>
-      </v-tooltip>
-      <v-tooltip
-        v-if="write_perm"
-        bottom
-      >
-        <template #activator="{on, attrs}">
-          <v-btn
-            class="mx-1"
-            fab
-            dark
-            small
-            href="/kondo_choice/"
-            color="#483682 accent"
-            v-bind="attrs"
-            v-on="on"
-          >
-            <v-icon>
-              mdi-cog
-            </v-icon>
-          </v-btn>
-        </template>
-        <span>Config Dropdown Lists</span>
-      </v-tooltip>
-    </v-app-bar>
-
+    <NavMenu
+      current-page="unique"
+      has-write-permissions="write_perms"
+      page-title="Unique Projects"
+    />
     <v-main>
       <UniqueProjectsList />
     </v-main>
@@ -109,6 +13,7 @@
 
 <script>
 import UniqueProjectsList from '../../components/UniqueProjectsList';
+import NavMenu from '../../components/NavMenu.vue';
 let perms = false
 try {
   const cookie = document.cookie
@@ -127,6 +32,7 @@ export default {
 
   components: {
     UniqueProjectsList,
+    NavMenu
   },
 
   data: () => ({

--- a/hxydra/src/pages/kondo_uniqueprojects/App.vue
+++ b/hxydra/src/pages/kondo_uniqueprojects/App.vue
@@ -2,7 +2,7 @@
   <v-app>
     <NavMenu
       current-page="unique"
-      has-write-permissions="write_perms"
+      :has-write-perms="write_perms"
       page-title="Unique Projects"
     />
     <v-main>
@@ -14,19 +14,8 @@
 <script>
 import UniqueProjectsList from '../../components/UniqueProjectsList';
 import NavMenu from '../../components/NavMenu.vue';
-let perms = false
-try {
-  const cookie = document.cookie
-  if (typeof(cookie) !== "undefined") {
-    let cookie_split = cookie.split(';').map(x => x.split('='))
-    let perm_cookie_val = cookie_split.filter(y => y.length == 2 ? y[0].trim() == 'hx-perms' : false)
-    if (perm_cookie_val.length > 0) {
-      perms = perm_cookie_val[0][1].trim().indexOf('kondo-editor') > -1
-    }
-  }
-} catch {
-  perms = false
-}
+import getPermissionsFromCookie from '../../resources/permissions';
+
 export default {
   name: 'App',
 
@@ -36,7 +25,7 @@ export default {
   },
 
   data: () => ({
-    write_perm: perms
+    write_perms: getPermissionsFromCookie()
   }),
 };
 </script>

--- a/hxydra/src/pages/kondo_uniqueprojects/main.js
+++ b/hxydra/src/pages/kondo_uniqueprojects/main.js
@@ -1,0 +1,11 @@
+import Vue from 'vue'
+import App from './App.vue'
+import Vuetify from 'vuetify'
+
+Vue.config.productionTip = false
+Vue.use(Vuetify)
+
+new Vue({
+  vuetify: new Vuetify(),
+  render: h => h(App)
+}).$mount('#app')

--- a/hxydra/src/resources/permissions.js
+++ b/hxydra/src/resources/permissions.js
@@ -1,0 +1,45 @@
+module.exports = function getPermissionsFromCookie() {
+    permissions = {
+        admin: false,
+        read: true,
+        create: false,
+        update: false,
+        delete: false
+    }
+    try {
+        const cookies = document.cookie.split(';').map(item => item.split('=')).reduce((acc, [k, v]) => (acc[k.trim().replace('"', '')] = v) && acc, {});
+        if (typeof(cookies) !== "undefined") {
+            const cookie_perms = cookies['hx-perms'];
+            if (cookie_perms.indexOf('kondo-admin') > 0 || cookie_perms.indexOf('kondo-operation') > 0 || cookie_perms.indexOf('kondo-admin') > 0 || cookie_perms.indexOf('kondo-editor') > 0) {
+                permissions.admin = true
+                permissions.create = true
+                permissions.update = true
+                permissions.delete = true
+            }
+            if (cookie_perms.indexOf('kondo-finance') > 0) {
+                permissions.update = true
+            }
+            if (cookie_perms.indexOf('kondo-production') > 0) {
+                permissions.update = true
+            }
+            if (cookie_perms.indexOf('kondo-create-project') > 0) {
+                permissions.create = true
+            }
+            if (cookie_perms.indexOf('kondo-delete-project') > 0) {
+                permissions.delete = true
+            }
+            if (cookie_perms.indexOf('kondo-update-project') > 0) {
+                permissions.update = true
+            }
+        }
+    } catch {
+        permissions = {
+            admin: false,
+            read: true,
+            create: false,
+            update: false,
+            delete: false
+        }
+    }
+    return permissions
+}

--- a/hxydra/vue.config.js
+++ b/hxydra/vue.config.js
@@ -43,6 +43,12 @@ module.exports = {
       template: 'public/kondo_reportview.html',
       title: 'Report View',
       chunks: ['chunk-vendors', 'chunk-common', 'kondo_reportview']
+    },
+    'kondo_uniqueprojects': {
+      entry: './src/pages/kondo_uniqueprojects/main.js',
+      template: 'public/kondo_uniqueprojects.html',
+      title: 'Unique Projects List',
+      chunks: ['chunk-vendors', 'chunk-common', 'kondo_uniqueprojects']
     }
   }
 }


### PR DESCRIPTION
Unique Projects Page that goes along with the pre-baked report. This page in particular was made to quickly search through them, but also in order for there to be an easier method for production to check off what videos have been archived. This page will require some changing if the need extend beyonds this particular case.

Both the unique projects list and the main edit form for the project now have field-level permissions. The backend adds users into groups. the groups have field-level permissions. There is a `permissions` parameter I can send to certain API calls which will return to me which items can be edited by the user (even if they can read everything). When sending back a POST/UPDATE/PATCH call, the backend ignores any field that the user does not have write-permissions for even if the front-end erroneously changes them. 